### PR TITLE
Fix method calls in named arg values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.0.2
+
+* Fix method calls in named arg values
+
 # v1.0.1
 
 * Void elements are rendered correctly

--- a/spec/instance_template/kw_args_spec.cr
+++ b/spec/instance_template/kw_args_spec.cr
@@ -6,6 +6,22 @@ module ToHtml::InstanceTemplate::KwArgsSpec
       a href: "https://www.example.com" do
         "example.com"
       end
+      a href: Paths.some_uri do
+        "Test"
+      end
+      img src: Paths.other_uri
+    end
+  end
+
+  module Paths
+    extend self
+
+    def some_uri
+      "https://some.example.com"
+    end
+
+    def other_uri
+      "https://example.com/test.png"
     end
   end
 
@@ -13,8 +29,10 @@ module ToHtml::InstanceTemplate::KwArgsSpec
     it "should return the correct HTML" do
       view = MyView.new
 
-      expected = <<-HTML
+      expected = <<-HTML.squish
       <a href="https://www.example.com">example.com</a>
+      <a href="https://some.example.com">Test</a>
+      <img src="https://example.com/test.png">
       HTML
 
       view.to_html.should eq(expected.squish)

--- a/src/instance_template.cr
+++ b/src/instance_template.cr
@@ -121,10 +121,10 @@ module ToHtml
     {% end %}
     {% if call.args.empty? && !call.named_args && call.block && call.block.body.is_a?(StringLiteral) %}
       {{io}} << {{"<" + call.name.stringify + ">" + call.block.body + "</" + call.name.stringify + ">"}}
-    {% elsif call.args.empty? && call.named_args && call.block && call.block.body.is_a?(StringLiteral) %}
+    {% elsif call.args.empty? && call.named_args && call.named_args.all? { |arg| arg.value.is_a?(StringLiteral) } && call.block && call.block.body.is_a?(StringLiteral) %}
       {{io}} << {{"<" + call.name.stringify + " " + call.named_args.map { |a| "#{a.name}=#{a.value}" }.join(" ") + ">" + call.block.body + "</" + call.name.stringify + ">"}}
     {% else %}
-      {% if call.named_args && call.args.empty? %}
+      {% if call.named_args && call.args.empty? && call.named_args.all? { |arg| arg.value.is_a?(StringLiteral) } %}
         {{io}} << {{"<" + call.name.stringify + " " + call.named_args.map { |a| "#{a.name}=#{a.value}" } .join(" ") + ">"}}
       {% else %}
         %attr_hash = ToHtml::AttributeHash.new
@@ -177,7 +177,7 @@ module ToHtml
     {% end %}
     {% if call.args.empty? && !call.named_args %}
       {{io}} << "<{{call.name}}>"
-    {% elsif call.args.empty? && call.named_args %}
+    {% elsif call.args.empty? && call.named_args && call.named_args.all? { |arg| arg.value.is_a?(StringLiteral) } %}
       {{io}} << "<{{call.name}} " + {{ call.named_args.map { |a| "#{a.name}=#{a.value}" }.join(" ") }} + ">"
     {% else %}
       %attr_hash = ToHtml::AttributeHash.new


### PR DESCRIPTION
Benchmark:
```
         ecr 872.90k (  1.15µs) (± 3.30%)  4.25kB/op          fastest
     to_html 533.39k (  1.87µs) (± 1.18%)  5.34kB/op     1.64× slower
html_builder  64.14k ( 15.59µs) (± 0.41%)  10.5kB/op    13.61× slower
       water  61.31k ( 16.31µs) (± 1.15%)  11.5kB/op    14.24× slower
   blueprint 868.17  (  1.15ms) (±19.16%)  6.89MB/op  1005.44× slower
```