### PR TITLE
Support array arguments to tag methods

### DIFF
--- a/spec/instance_template/attributes_spec.cr
+++ b/spec/instance_template/attributes_spec.cr
@@ -2,14 +2,22 @@ require "../spec_helper"
 
 module ToHtml::InstanceTemplate::AttributesSpec
   class MyView
+    SPECIAL_CSS_CLASSES = [MyCssClass, MyOtherCssClass]
+
     ToHtml.instance_template do
-      div MyCssClass, MyOtherCssClass, {"class", "so-unique"} do
+      div MyCssClass, MyOtherCssClass, {"class", "so-unique"}, more_css_classes do
+        span(SPECIAL_CSS_CLASSES) { "Blah" }
+        img SPECIAL_CSS_CLASSES, more_css_classes
         div MyStimulusController do
           p({"class", "so-special"}) do
             "Some content"
           end
         end
       end
+    end
+
+    def more_css_classes
+      [MyThirdCssClass, ThatOtherCssClass]
     end
   end
 
@@ -22,6 +30,18 @@ module ToHtml::InstanceTemplate::AttributesSpec
   class MyOtherCssClass
     def self.to_html_attrs(tag, attr_hash)
       attr_hash["class"] = "my-other-css-class"
+    end
+  end
+
+  class MyThirdCssClass
+    def self.to_html_attrs(tag, attr_hash)
+      attr_hash["class"] = "my-third-css-class"
+    end
+  end
+
+  class ThatOtherCssClass
+    def self.to_html_attrs(tag, attr_hash)
+      attr_hash["class"] = "that-other-css-class"
     end
   end
 
@@ -38,7 +58,9 @@ module ToHtml::InstanceTemplate::AttributesSpec
         view = MyView.new
 
         expected = <<-HTML
-        <div class="my-css-class my-other-css-class so-unique">
+        <div class="my-css-class my-other-css-class so-unique my-third-css-class that-other-css-class">
+          <span class="my-css-class my-other-css-class">Blah</span>
+          <img class="my-css-class my-other-css-class my-third-css-class that-other-css-class">
           <div data-controller="my" data-action="click->handle_click()">
             <p class="so-special">Some content</p>
           </div>

--- a/src/instance_template.cr
+++ b/src/instance_template.cr
@@ -136,7 +136,14 @@ module ToHtml
           {% if arg.is_a?(TupleLiteral) %}
             %attr_hash[{{arg}}.first] = {{arg}}.last
           {% else %}
-            {{arg}}.to_html_attrs({{call.name.stringify}}, %attr_hash)
+            %arg = {{arg}}
+            if %arg.is_a?(Array)
+              %arg.each do |item|
+                item.to_html_attrs({{call.name.stringify}}, %attr_hash)
+              end
+            else
+              %arg.to_html_attrs({{call.name.stringify}}, %attr_hash)
+            end
           {% end %}
         {% end %}
 
@@ -190,7 +197,14 @@ module ToHtml
         {% if arg.is_a?(TupleLiteral) %}
           %attr_hash[{{arg}}.first] = {{arg}}.last
         {% else %}
-          {{arg}}.to_html_attrs({{call.name.stringify}}, %attr_hash)
+          %arg = {{arg}}
+          if %arg.is_a?(Array)
+            %arg.each do |item|
+              item.to_html_attrs({{call.name.stringify}}, %attr_hash)
+            end
+          else
+            %arg.to_html_attrs({{call.name.stringify}}, %attr_hash)
+          end
         {% end %}
       {% end %}
 


### PR DESCRIPTION
Benchmark:
```
$ crystal run --release benchmark/benchmark.cr
         ecr 993.75k (  1.01µs) (± 0.70%)  4.25kB/op          fastest
     to_html 605.46k (  1.65µs) (± 2.01%)  5.34kB/op     1.64× slower
html_builder  67.71k ( 14.77µs) (± 0.99%)  10.4kB/op    14.68× slower
       water  64.51k ( 15.50µs) (± 0.94%)  11.2kB/op    15.40× slower
   blueprint 880.85  (  1.14ms) (±15.78%)  6.63MB/op  1128.17× slower
```