### PR TITLE
Fix nested if evaluation

### DIFF
--- a/spec/instance_template/if_spec.cr
+++ b/spec/instance_template/if_spec.cr
@@ -11,7 +11,12 @@ module ToHtml::InstanceTemplate::IfSpec
 
     ToHtml.instance_template do
       if switch
-        p { "Hooray!" }
+        # nested ifs should work, too
+        if !!switch
+          if true && switch
+            p { "Hooray!" }
+          end
+        end
       end
       div do
         if switch

--- a/src/instance_template.cr
+++ b/src/instance_template.cr
@@ -82,7 +82,7 @@ module ToHtml
       end
     {% elsif blk.body.is_a?(If) %}
       if {{blk.body.cond}}
-        {% if blk.body.then %}
+        {% if !blk.body.then.nil? %}
           ToHtml.to_html_eval_exps({{io}}, {{indent_level}}) do
             {{blk.body.then}}
           end
@@ -90,7 +90,7 @@ module ToHtml
             {{io}} << "\n"
           {% end %}
         {% end %}
-      {% if blk.body.else %}
+      {% if !blk.body.else.nil? %}
         else
           ToHtml.to_html_eval_exps({{io}}, {{indent_level}}) do
             {{blk.body.else}}


### PR DESCRIPTION
Benchmark:
```
         ecr 841.72k (  1.19µs) (± 1.43%)  4.25kB/op         fastest
     to_html 516.59k (  1.94µs) (± 0.75%)   5.5kB/op    1.63× slower
html_builder  57.01k ( 17.54µs) (± 1.68%)  10.4kB/op   14.76× slower
       water  56.43k ( 17.72µs) (± 0.49%)  11.2kB/op   14.92× slower
   blueprint 851.24  (  1.17ms) (±16.22%)  6.66MB/op  988.82× slower
```