### PR TITLE
Fix boolean attributes with literal values

### DIFF
--- a/spec/instance_template/attributes_spec.cr
+++ b/spec/instance_template/attributes_spec.cr
@@ -21,10 +21,13 @@ module ToHtml::InstanceTemplate::AttributesSpec
           "Options"
         end
         select_tag id: SomeId.to_s, name: "myselect" do
+          option(value: "", selected: false) { "-" }
           ["one", "two", "three"].each do |val|
             option(value: val, selected: val == DEFAULT_VALUE) { val }
           end
         end
+        input name: "name", type: "text", required: true
+        input name: "surname", type: "text", required: false
       end
     end
 
@@ -86,10 +89,13 @@ module ToHtml::InstanceTemplate::AttributesSpec
         <fieldset>
           <label for="some-id">Options</label>
           <select id="some-id" name="myselect">
+            <option value="">-</option>
             <option value="one">one</option>
             <option value="two" selected>two</option>
             <option value="three">three</option>
           </select>
+          <input name="name" type="text" required>
+          <input name="surname" type="text">
         </fieldset>
         HTML
 

--- a/src/instance_template.cr
+++ b/src/instance_template.cr
@@ -149,7 +149,7 @@ module ToHtml
 
         {% if call.named_args %}
           {% for named_arg in call.named_args %}
-            %attr_hash[{{named_arg.name.stringify}}] = {{named_arg.value}}.to_s
+            %attr_hash[{{named_arg.name.stringify}}] = {{named_arg.value}}
           {% end %}
         {% end %}
 
@@ -210,7 +210,7 @@ module ToHtml
 
       {% if call.named_args %}
         {% for named_arg in call.named_args %}
-          %attr_hash[{{named_arg.name.stringify}}] = {{named_arg.value}}.to_s
+          %attr_hash[{{named_arg.name.stringify}}] = {{named_arg.value}}
         {% end %}
       {% end %}
 


### PR DESCRIPTION
Fixes #8 

Benchmark (new machine):
```
         ecr   1.43M (700.58ns) (± 1.91%)  4.25kB/op          fastest
     to_html 827.17k (  1.21µs) (± 1.36%)   5.5kB/op     1.73× slower
html_builder  59.39k ( 16.84µs) (± 1.13%)  10.4kB/op    24.03× slower
       water  58.85k ( 16.99µs) (± 1.08%)  11.2kB/op    24.26× slower
   blueprint 994.85  (  1.01ms) (±18.90%)  9.29MB/op  1434.79× slower
```