### PR TITLE
Always convert attribute values to String

### DIFF
--- a/spec/instance_template/attributes_spec.cr
+++ b/spec/instance_template/attributes_spec.cr
@@ -17,10 +17,10 @@ module ToHtml::InstanceTemplate::AttributesSpec
       end
 
       fieldset do
-        label for: SomeId.to_s do
+        label for: SomeId do
           "Options"
         end
-        select_tag id: SomeId.to_s, name: "myselect" do
+        select_tag id: SomeId, name: "myselect" do
           option(value: "", selected: false) { "-" }
           ["one", "two", "three"].each do |val|
             option(value: val, selected: val == DEFAULT_VALUE) { val }

--- a/spec/instance_template/attributes_spec.cr
+++ b/spec/instance_template/attributes_spec.cr
@@ -8,7 +8,7 @@ module ToHtml::InstanceTemplate::AttributesSpec
     ToHtml.instance_template do
       div MyCssClass, MyOtherCssClass, {"class", "so-unique"}, more_css_classes do
         span(SPECIAL_CSS_CLASSES) { "Blah" }
-        img SPECIAL_CSS_CLASSES, more_css_classes
+        img SPECIAL_CSS_CLASSES, more_css_classes, {"class", nil}
         div MyStimulusController do
           p({"class", "so-special"}) do
             "Some content"

--- a/src/attribute_hash.cr
+++ b/src/attribute_hash.cr
@@ -19,7 +19,7 @@ module ToHtml
       if attributes.has_key?(key)
         attributes[key] += " #{value}"
       else
-        attributes[key] = value
+        attributes[key] = value.to_s
       end
     end
 

--- a/src/attribute_hash.cr
+++ b/src/attribute_hash.cr
@@ -17,7 +17,7 @@ module ToHtml
 
     def []=(key, value)
       if attributes.has_key?(key)
-        attributes[key] += " #{value}"
+        attributes[key] += " #{value}" if value
       else
         attributes[key] = value.to_s
       end


### PR DESCRIPTION
Fixes #10 

Benchmark:
```
         ecr   1.40M (714.96ns) (± 3.21%)  4.25kB/op          fastest
     to_html 822.98k (  1.22µs) (± 1.03%)   5.5kB/op     1.70× slower
html_builder  58.64k ( 17.05µs) (± 0.82%)  10.4kB/op    23.85× slower
       water  58.64k ( 17.05µs) (± 1.67%)  11.2kB/op    23.85× slower
   blueprint   1.00k (996.28µs) (±18.82%)  9.13MB/op  1393.48× slower
```