### PR TITLE
Only interpret calls w/o receiver as HTML tags

### DIFF
--- a/spec/instance_template/chained_method_calls_spec.cr
+++ b/spec/instance_template/chained_method_calls_spec.cr
@@ -16,31 +16,43 @@ module ToHtml::InstanceTemplate::ChainedMethodCallsSpec
         span { "Age" }
         span { my_model.age }
       end
+      div do
+        span { "Form" }
+        span { my_model.form }
+      end
+      div do
+        span { "Input" }
+        span { my_model.input }
+      end
     end
   end
 
-  record MyModel, name : String, age : Int32
+  record MyModel, name : String, age : Int32, form : String, input : String
 
   describe "MyView#to_html" do
     it "should return the correct HTML" do
-      view = MyView.new(MyModel.new("Stefan", 36))
+      view = MyView.new(MyModel.new("Stefan", 36, "final", "important!"))
 
-      expected = <<-HTML
+      expected = <<-HTML.squish
       <div>
         <span>Name</span>
-        <span>
-          Stefan
-        </span>
+        <span>Stefan</span>
       </div>
       <div>
         <span>Age</span>
-        <span>
-          36
-        </span>
+        <span>36</span>
+      </div>
+      <div>
+        <span>Form</span>
+        <span>final</span>
+      </div>
+      <div>
+        <span>Input</span>
+        <span>important!</span>
       </div>
       HTML
 
-      view.to_html.should eq(expected.squish)
+      view.to_html.should eq(expected)
     end
   end
 end

--- a/src/instance_template.cr
+++ b/src/instance_template.cr
@@ -59,11 +59,11 @@ module ToHtml
 
   # :nodoc:
   macro to_html_eval_exp(io, indent_level, break_line = true, &blk)
-    {% if blk.body.is_a?(Call) && ToHtml::VOID_TAG_NAMES.includes?(blk.body.name.stringify) %}
+    {% if blk.body.is_a?(Call) && blk.body.receiver.nil? && ToHtml::VOID_TAG_NAMES.includes?(blk.body.name.stringify) %}
       ToHtml.to_html_add_void_tag({{io}}, {{indent_level}}, {{break_line}}, {{blk.body}})
-    {% elsif blk.body.is_a?(Call) && ToHtml::TAG_NAMES.keys.includes?(blk.body.name.stringify) %}
+    {% elsif blk.body.is_a?(Call) && blk.body.receiver.nil? && ToHtml::TAG_NAMES.keys.includes?(blk.body.name.stringify) %}
       ToHtml.to_html_add_tag({{io}}, {{indent_level}}, {{break_line}}, {{blk.body}})
-    {% elsif blk.body.is_a?(Call) && blk.body.name.stringify == "doctype" %}
+    {% elsif blk.body.is_a?(Call) && blk.body.receiver.nil? && blk.body.name.stringify == "doctype" %}
       {{io}} << "<!DOCTYPE {{blk.body.args.first.id}}>"
     {% elsif blk.body.is_a?(Call) && blk.body.receiver && blk.body.name.stringify == "each" %}
       {{blk.body.receiver}}.each_with_index do {% if !blk.body.block.args.empty? %} |{{blk.body.block.args.splat}}, %index| {% end %}


### PR DESCRIPTION
Benchmark:
```
         ecr   1.45M (687.70ns) (± 1.45%)  4.25kB/op          fastest
     to_html 828.66k (  1.21µs) (± 0.95%)   5.5kB/op     1.75× slower
html_builder  69.31k ( 14.43µs) (± 0.96%)  10.4kB/op    20.98× slower
       water  68.17k ( 14.67µs) (± 2.22%)  11.2kB/op    21.33× slower
   blueprint   1.03k (969.50µs) (±18.29%)  9.28MB/op  1409.76× slower
```