### PR TITLE
Add `markout` shard to benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,11 +262,12 @@ Have a look into the `benchmark/` folder to find out how these numbers were dete
 Execute `crystal run --release benchmark/benchmark.cr` to reproduce.
 
 ```
-         ecr 911.95k (  1.10µs) (± 8.27%)  4.25kB/op          fastest
-     to_html 562.93k (  1.78µs) (± 1.56%)  5.34kB/op     1.62× slower
-html_builder  68.24k ( 14.66µs) (± 0.83%)  10.5kB/op    13.36× slower
-       water  64.78k ( 15.44µs) (± 0.89%)  11.5kB/op    14.08× slower
-   blueprint 803.30  (  1.24ms) (±14.30%)  6.32MB/op  1135.26× slower
+         ecr   1.55M (645.91ns) (± 5.16%)  4.27kB/op        fastest
+     to_html 902.82k (  1.11µs) (± 8.18%)  5.52kB/op   1.71× slower
+   blueprint 170.78k (  5.86µs) (± 8.85%)   9.8kB/op   9.07× slower
+html_builder  62.44k ( 16.01µs) (± 3.41%)  10.4kB/op  24.79× slower
+       water  61.90k ( 16.16µs) (± 1.18%)  11.2kB/op  25.01× slower
+     markout  44.77k ( 22.34µs) (± 1.72%)  15.6kB/op  34.58× slower
 ```
 
 Compared shards taken from [awesome-crystal](https://github.com/veelenga/awesome-crystal#html-builders)

--- a/benchmark/benchmark.cr
+++ b/benchmark/benchmark.cr
@@ -4,12 +4,14 @@ require "./ecr"
 require "./blueprint"
 require "./water"
 require "./html_builder"
+require "./markout"
 
 to_html = ToHtml::Benchmark::ToHtmlTemplate.new
 ecr = ToHtml::Benchmark::EcrTemplate.new
 blueprint = ToHtml::Benchmark::BlueprintTemplate.new
 water = ToHtml::Benchmark::WaterTemplate.new
 html_builder = ToHtml::Benchmark::HtmlBuilderTemplate.new
+markout = ToHtml::Benchmark::MarkoutTemplate.new
 
 def normalize(input)
   input.gsub(/'/, "\"").split(/\n\s*/).join
@@ -21,7 +23,8 @@ to_html_output = normalize(to_html.to_html)
   "ecr" => normalize(ecr.to_s),
   "blueprint" => normalize(blueprint.to_html),
   "water" => normalize(water.to_html),
-  "html_builder" => normalize(html_builder.to_s)
+  "html_builder" => normalize(html_builder.to_s),
+  "markout" => normalize(markout.to_s)
 }.each do |name, output|
   if to_html_output != output
     puts to_html_output
@@ -37,4 +40,5 @@ Benchmark.ips do |x|
   x.report("blueprint") { ToHtml::Benchmark::BlueprintTemplate.new.to_html }
   x.report("html_builder") { ToHtml::Benchmark::HtmlBuilderTemplate.new.to_s }
   x.report("water") { ToHtml::Benchmark::WaterTemplate.new.to_html }
+  x.report("markout") { ToHtml::Benchmark::MarkoutTemplate.new.to_s }
 end

--- a/benchmark/benchmark.cr
+++ b/benchmark/benchmark.cr
@@ -12,7 +12,7 @@ water = ToHtml::Benchmark::WaterTemplate.new
 html_builder = ToHtml::Benchmark::HtmlBuilderTemplate.new
 
 def normalize(input)
-  input.split(/\n\s*/).join
+  input.gsub(/'/, "\"").split(/\n\s*/).join
 end
 
 to_html_output = normalize(to_html.to_html)

--- a/benchmark/benchmark.cr
+++ b/benchmark/benchmark.cr
@@ -32,9 +32,9 @@ to_html_output = normalize(to_html.to_html)
 end
 
 Benchmark.ips do |x|
-  x.report("ecr") { ecr.to_s }
-  x.report("to_html") { to_html.to_html }
-  x.report("html_builder") { html_builder.to_s }
-  x.report("water") { water.to_html }
-  x.report("blueprint") { blueprint.to_html }
+  x.report("ecr") { ToHtml::Benchmark::EcrTemplate.new.to_s }
+  x.report("to_html") { ToHtml::Benchmark::ToHtmlTemplate.new.to_html }
+  x.report("blueprint") { ToHtml::Benchmark::BlueprintTemplate.new.to_html }
+  x.report("html_builder") { ToHtml::Benchmark::HtmlBuilderTemplate.new.to_s }
+  x.report("water") { ToHtml::Benchmark::WaterTemplate.new.to_html }
 end

--- a/benchmark/markout.cr
+++ b/benchmark/markout.cr
@@ -1,0 +1,62 @@
+require "markout"
+
+module ToHtml
+  module Benchmark
+    class MarkoutTemplate
+      include Markout::Component
+
+      def initialize
+        render("foo", ["Peter", "Paul", "Mary"])
+      end
+
+      def render(some_string, names)
+        h1 "Benchmark"
+
+        h2 "Long Text"
+
+        div class: "long-text" do
+          p do
+            text "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet."
+          end
+        end
+
+        h2 "Deeply Nested"
+        div class: "some" do
+          div class: "deeply" do
+            div class: "nested", foo: "bar" do
+              div class: "but" do
+                div class: "still" do
+                  div class: "very" do
+                    div class: "interesting", bar: "foo" do
+                      div class: "html" do
+                        div class: "elements" do
+                          div class: "isnt" do
+                            div class: "that" do
+                              span "beautiful"
+                            end
+                          end
+                        end
+                      end
+                    end
+                  end
+                end
+              end
+            end
+          end
+        end
+
+        h2 "Method Call"
+        div class: "method-call" do
+          span some_string
+        end
+
+        h2 "Iteration"
+        ul do
+          names.each do |name|
+            li name
+          end
+        end
+      end
+    end
+  end
+end

--- a/shard.lock
+++ b/shard.lock
@@ -8,6 +8,10 @@ shards:
     git: https://github.com/crystal-lang/html_builder.git
     version: 0.2.2
 
+  markout:
+    git: https://github.com/grottopress/markout.git
+    version: 1.0.0
+
   water:
     git: https://github.com/shootingfly/water.git
     version: 1.0.0

--- a/shard.yml
+++ b/shard.yml
@@ -12,3 +12,5 @@ development_dependencies:
     github: shootingfly/water
   html_builder:
     github: crystal-lang/html_builder
+  markout:
+    github: GrottoPress/markout


### PR DESCRIPTION
Branch benchmark can be found in the changes.

What stands out is the drastically increased performance of `blueprint` once I didn't reuse the same object for rendering all over again but instantiated a new one each run. This didn't have any effect on all the other shards tested here. I can't explain why this is, but I'll leave it that way now. (cc @stephannv sorry I made your shard look worse than it actually is until now, that wasn't on purpose)