### PR TITLE
Implement NamedTuple#to_html_attrs

### DIFF
--- a/spec/instance_template/attributes_spec.cr
+++ b/spec/instance_template/attributes_spec.cr
@@ -7,7 +7,7 @@ module ToHtml::InstanceTemplate::AttributesSpec
 
     ToHtml.instance_template do
       div MyCssClass, MyOtherCssClass, {"class", "so-unique"}, more_css_classes do
-        span(SPECIAL_CSS_CLASSES) { "Blah" }
+        span(SPECIAL_CSS_CLASSES, {class: "moo"}) { "Blah" }
         img SPECIAL_CSS_CLASSES, more_css_classes, {"class", nil}
         div MyStimulusController do
           p({"class", "so-special"}) do
@@ -80,7 +80,7 @@ module ToHtml::InstanceTemplate::AttributesSpec
 
         expected = <<-HTML
         <div class="my-css-class my-other-css-class so-unique my-third-css-class that-other-css-class">
-          <span class="my-css-class my-other-css-class">Blah</span>
+          <span class="my-css-class my-other-css-class moo">Blah</span>
           <img class="my-css-class my-other-css-class my-third-css-class that-other-css-class">
           <div data-controller="my" data-action="click->handle_click()">
             <p class="so-special">Some content</p>

--- a/src/ext/named_tuple.cr
+++ b/src/ext/named_tuple.cr
@@ -1,0 +1,7 @@
+struct NamedTuple
+  def to_html_attrs(_tag, attr_hash)
+    each do |key, value|
+      attr_hash[key.to_s] = value
+    end
+  end
+end

--- a/src/to_html.cr
+++ b/src/to_html.cr
@@ -1,2 +1,3 @@
 require "./instance_template"
 require "./instance_tag_attrs"
+require "./ext/**"


### PR DESCRIPTION
Benchmark:
```
         ecr   1.69M (592.20ns) (± 4.85%)  4.27kB/op        fastest
     to_html 981.86k (  1.02µs) (± 0.70%)  5.52kB/op   1.72× slower
   blueprint 179.96k (  5.56µs) (± 2.65%)   9.8kB/op   9.38× slower
html_builder  63.51k ( 15.75µs) (± 0.43%)  10.4kB/op  26.59× slower
       water  61.96k ( 16.14µs) (± 1.01%)  11.2kB/op  27.25× slower
     markout  45.44k ( 22.01µs) (± 0.47%)  15.6kB/op  37.16× slower
```