### PR TITLE
Upgrade blueprint benchmark template

### DIFF
--- a/benchmark/blueprint.cr
+++ b/benchmark/blueprint.cr
@@ -14,17 +14,15 @@ module ToHtml
       end
 
       private def blueprint
-        h1 { "Benchmark" }
+        h1 "Benchmark"
 
-        h2 { "Long Text" }
+        h2 "Long Text"
 
         div class: "long-text" do
-          p do
-            "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet."
-          end
+          p "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet."
         end
 
-        h2 { "Deeply Nested" }
+        h2 "Deeply Nested"
         div class: "some" do
           div class: "deeply" do
             div class: "nested", foo: "bar" do
@@ -36,7 +34,7 @@ module ToHtml
                         div class: "elements" do
                           div class: "isnt" do
                             div class: "that" do
-                              span { "beautiful" }
+                              span "beautiful"
                             end
                           end
                         end
@@ -49,15 +47,15 @@ module ToHtml
           end
         end
 
-        h2 { "Method Call" }
+        h2 "Method Call"
         div class: "method-call" do
-          span { some_string }
+          span some_string
         end
 
-        h2 { "Iteration" }
+        h2 "Iteration"
         ul do
           names.each do |name|
-            li { name }
+            li name
           end
         end
       end

--- a/shard.lock
+++ b/shard.lock
@@ -2,7 +2,7 @@ version: 2.0
 shards:
   blueprint:
     git: https://github.com/stephannv/blueprint.git
-    version: 0.4.0
+    version: 0.6.0
 
   html_builder:
     git: https://github.com/crystal-lang/html_builder.git


### PR DESCRIPTION
Hey, I was working on Blueprint perf improvements today and I got improved numbers. It's not close to `to_html` times but at least it's something.
Two things that contributed:
- Using String::Builder instead IO::Memory 🤦🏽
- Allowing passing content without using blocks, eg. `h1("Hello")`.

```
         ecr   3.48M (286.99ns) (± 1.11%)  4.27kB/op        fastest
     to_html   1.90M (525.41ns) (± 0.88%)  5.52kB/op   1.83× slower
   blueprint 481.79k (  2.08µs) (± 0.78%)   9.8kB/op   7.23× slower
html_builder 118.20k (  8.46µs) (± 0.85%)  10.4kB/op  29.48× slower
       water 114.23k (  8.75µs) (± 0.59%)  11.2kB/op  30.50× slower
     markout  89.04k ( 11.23µs) (± 0.74%)  15.6kB/op  39.13× slower
```