### PR TITLE
Upgrade blueprint benchmark template

### DIFF
--- a/benchmark/benchmark.cr
+++ b/benchmark/benchmark.cr
@@ -9,6 +9,7 @@ require "./markout"
 to_html = ToHtml::Benchmark::ToHtmlTemplate.new
 ecr = ToHtml::Benchmark::EcrTemplate.new
 blueprint = ToHtml::Benchmark::BlueprintTemplate.new
+raw_blueprint = ToHtml::Benchmark::RawBlueprintTemplate.new
 water = ToHtml::Benchmark::WaterTemplate.new
 html_builder = ToHtml::Benchmark::HtmlBuilderTemplate.new
 markout = ToHtml::Benchmark::MarkoutTemplate.new
@@ -22,6 +23,7 @@ to_html_output = normalize(to_html.to_html)
 {
   "ecr" => normalize(ecr.to_s),
   "blueprint" => normalize(blueprint.to_html),
+  "raw_blueprint" => normalize(raw_blueprint.to_html),
   "water" => normalize(water.to_html),
   "html_builder" => normalize(html_builder.to_s),
   "markout" => normalize(markout.to_s)
@@ -37,6 +39,7 @@ end
 Benchmark.ips do |x|
   x.report("ecr") { ToHtml::Benchmark::EcrTemplate.new.to_s }
   x.report("to_html") { ToHtml::Benchmark::ToHtmlTemplate.new.to_html }
+  x.report("raw blueprint") { ToHtml::Benchmark::RawBlueprintTemplate.new.to_html }
   x.report("blueprint") { ToHtml::Benchmark::BlueprintTemplate.new.to_html }
   x.report("html_builder") { ToHtml::Benchmark::HtmlBuilderTemplate.new.to_s }
   x.report("water") { ToHtml::Benchmark::WaterTemplate.new.to_html }

--- a/benchmark/blueprint.cr
+++ b/benchmark/blueprint.cr
@@ -1,4 +1,5 @@
 require "blueprint/html"
+require "blueprint/raw_html"
 
 module ToHtml
   module Benchmark
@@ -14,17 +15,15 @@ module ToHtml
       end
 
       private def blueprint
-        h1 { "Benchmark" }
+        h1 "Benchmark"
 
-        h2 { "Long Text" }
+        h2 "Long Text"
 
         div class: "long-text" do
-          p do
-            "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet."
-          end
+          p "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet."
         end
 
-        h2 { "Deeply Nested" }
+        h2 "Deeply Nested"
         div class: "some" do
           div class: "deeply" do
             div class: "nested", foo: "bar" do
@@ -36,7 +35,7 @@ module ToHtml
                         div class: "elements" do
                           div class: "isnt" do
                             div class: "that" do
-                              span { "beautiful" }
+                              span "beautiful"
                             end
                           end
                         end
@@ -49,15 +48,78 @@ module ToHtml
           end
         end
 
-        h2 { "Method Call" }
+        h2 "Method Call"
         div class: "method-call" do
-          span { some_string }
+          span some_string
         end
 
-        h2 { "Iteration" }
+        h2 "Iteration"
         ul do
           names.each do |name|
-            li { name }
+            li name
+          end
+        end
+      end
+    end
+  end
+end
+
+module ToHtml
+  module Benchmark
+    class RawBlueprintTemplate
+      include Blueprint::RawHTML
+
+      def some_string
+        "foo"
+      end
+
+      def names
+        ["Peter", "Paul", "Mary"]
+      end
+
+      private def blueprint
+        h1 "Benchmark"
+
+        h2 "Long Text"
+
+        div class: "long-text" do
+          p "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet."
+        end
+
+        h2 "Deeply Nested"
+        div class: "some" do
+          div class: "deeply" do
+            div class: "nested", foo: "bar" do
+              div class: "but" do
+                div class: "still" do
+                  div class: "very" do
+                    div class: "interesting", bar: "foo" do
+                      div class: "html" do
+                        div class: "elements" do
+                          div class: "isnt" do
+                            div class: "that" do
+                              span "beautiful"
+                            end
+                          end
+                        end
+                      end
+                    end
+                  end
+                end
+              end
+            end
+          end
+        end
+
+        h2 "Method Call"
+        div class: "method-call" do
+          span some_string
+        end
+
+        h2 "Iteration"
+        ul do
+          names.each do |name|
+            li name
           end
         end
       end

--- a/shard.lock
+++ b/shard.lock
@@ -2,7 +2,7 @@ version: 2.0
 shards:
   blueprint:
     git: https://github.com/stephannv/blueprint.git
-    version: 0.4.0
+    version: 0.7.0
 
   html_builder:
     git: https://github.com/crystal-lang/html_builder.git


### PR DESCRIPTION
I refactored some code and due to https://github.com/sbsoftware/to_html.cr/pull/16 I noticed that HTML.escape slow down the rendering, so I made available a version to those who controls the content being rendered and want to focus on performance. And some refactoring improved the safe blueprint too, from ~9x to ~5x, I think it was the reuse of the same buffer to build element attributes instead creating a new one for each element.
```
          ecr   3.45M (289.48ns) (± 1.51%)  4.27kB/op        fastest
      to_html   1.88M (533.03ns) (± 1.62%)  5.52kB/op   1.84× slower
raw blueprint   1.07M (938.61ns) (± 0.90%)   4.9kB/op   3.24× slower
    blueprint 628.81k (  1.59µs) (± 1.27%)   4.9kB/op   5.49× slower
 html_builder 117.60k (  8.50µs) (± 2.56%)  10.4kB/op  29.37× slower
        water 114.54k (  8.73µs) (± 0.68%)  11.2kB/op  30.16× slower
      markout  89.33k ( 11.19µs) (± 0.96%)  15.6kB/op  38.67× slower
```