### PR TITLE
Support macro expressions within templates

### DIFF
--- a/spec/instance_template/macro_for_spec.cr
+++ b/spec/instance_template/macro_for_spec.cr
@@ -1,0 +1,31 @@
+require "../spec_helper"
+
+module ToHtml::InstanceTemplate::MacroForSpec
+  class MyView
+    getter a : String
+    getter b : String
+
+    def initialize(@a, @b); end
+
+    ToHtml.instance_template do
+      form do
+        {% for ivar in @type.instance_vars %}
+          input type: :text, name: {{ivar.name.stringify}}, value: {{ivar.name.id}}
+        {% end %}
+      end
+    end
+  end
+
+  describe "MyView#to_html" do
+    it "should return the correct HTML" do
+      expected = <<-HTML.squish
+      <form>
+        <input type="text" name="a" value="foo">
+        <input type="text" name="b" value="bar">
+      </form>
+      HTML
+
+      MyView.new(a: "foo", b: "bar").to_html.should eq(expected)
+    end
+  end
+end

--- a/spec/instance_template/macro_if_spec.cr
+++ b/spec/instance_template/macro_if_spec.cr
@@ -1,0 +1,27 @@
+require "../spec_helper"
+
+module ToHtml::InstanceTemplate::MacroIfSpec
+  class MyView
+    ToHtml.class_template do
+      {% if false %}
+        p do
+          "Not shown"
+        end
+      {% else %}
+        p do
+          "Shown"
+        end
+      {% end %}
+    end
+  end
+
+  describe "MyView#to_html" do
+    it "should return the correct HTML" do
+      expected = <<-HTML.squish
+      <p>Shown</p>
+      HTML
+
+      MyView.to_html.should eq(expected)
+    end
+  end
+end

--- a/src/instance_template.cr
+++ b/src/instance_template.cr
@@ -112,6 +112,16 @@ module ToHtml
           {% end %}
       {% end %}
       end
+    {% elsif blk.body.is_a?(MacroIf) %}
+      \{% if {{blk.body.cond}} %}
+        ToHtml.to_html_eval_exps({{io}}, {{indent_level}}) do
+          {{blk.body.then}}
+        end
+      \{% else %}
+        ToHtml.to_html_eval_exps({{io}}, {{indent_level}}) do
+          {{blk.body.else}}
+        end
+      \{% end %}
     {% elsif blk.body.is_a?(MacroFor) %}
       \{% for {{blk.body.vars.splat}} in {{blk.body.exp}} %}
         ToHtml.to_html_eval_exps({{io}}, {{indent_level}}) do

--- a/src/instance_template.cr
+++ b/src/instance_template.cr
@@ -129,6 +129,8 @@ module ToHtml
           {{blk.body.body.stringify.gsub(/\n/, "").id}}
         end
       \{% end %}
+    {% elsif blk.body.is_a?(MacroExpression) || blk.body.is_a?(MacroLiteral) %}
+      {{blk.body}}
     {% elsif blk.body.is_a?(Assign) %}
       # Don't print this to the IO
       {{blk.body}}

--- a/src/instance_template.cr
+++ b/src/instance_template.cr
@@ -112,6 +112,13 @@ module ToHtml
           {% end %}
       {% end %}
       end
+    {% elsif blk.body.is_a?(MacroFor) %}
+      \{% for {{blk.body.vars.splat}} in {{blk.body.exp}} %}
+        ToHtml.to_html_eval_exps({{io}}, {{indent_level}}) do
+          # Crystal seems to insert a newline after each macro variable for some reason
+          {{blk.body.body.stringify.gsub(/\n/, "").id}}
+        end
+      \{% end %}
     {% elsif blk.body.is_a?(Assign) %}
       # Don't print this to the IO
       {{blk.body}}


### PR DESCRIPTION
Benchmark:
```bash
         ecr   1.66M (603.18ns) (± 2.98%)  4.27kB/op        fastest
     to_html 889.19k (  1.12µs) (± 5.07%)  5.52kB/op   1.86× slower
   blueprint 462.41k (  2.16µs) (± 3.20%)   4.9kB/op   3.59× slower
     markout 197.67k (  5.06µs) (± 5.84%)  8.08kB/op   8.39× slower
html_builder  60.56k ( 16.51µs) (± 1.92%)  10.4kB/op  27.38× slower
       water  59.21k ( 16.89µs) (± 3.85%)  11.2kB/op  28.00× slower
```