### PR TITLE
Remove indentation and pretty printing support 

### DIFF
--- a/spec/instance_template/yield_spec.cr
+++ b/spec/instance_template/yield_spec.cr
@@ -46,8 +46,8 @@ module ToHtml::InstanceTemplate::YieldSpec
       </html>
       HTML
 
-      layout.to_html do |io, indent_level|
-        View.to_html(io, indent_level)
+      layout.to_html do |io|
+        View.to_html(io)
       end.should eq(expected)
     end
   end

--- a/spec/instance_template/yield_spec.cr
+++ b/spec/instance_template/yield_spec.cr
@@ -32,7 +32,7 @@ module ToHtml::InstanceTemplate::YieldSpec
     it "should return the correct HTML" do
       layout = Layout.new("Hi")
 
-      expected = <<-HTML
+      expected = <<-HTML.squish
       <html>
         <head>
           <title>
@@ -48,7 +48,7 @@ module ToHtml::InstanceTemplate::YieldSpec
 
       layout.to_html do |io, indent_level|
         View.to_html(io, indent_level)
-      end.should eq(expected.squish)
+      end.should eq(expected)
     end
   end
 end

--- a/src/instance_template.cr
+++ b/src/instance_template.cr
@@ -6,8 +6,8 @@ module ToHtml
   extend TagTypechecks
 
   macro instance_template(&blk)
-    def to_html(io, indent_level = 0)
-      ToHtml.to_html_eval_exps(io, indent_level) {{blk}}
+    def to_html(io)
+      ToHtml.to_html_eval_exps(io) {{blk}}
     end
 
     def to_html
@@ -18,16 +18,16 @@ module ToHtml
 
     def to_html
       String.build do |io|
-        to_html(io) do |inner_io, indent_level|
-          yield inner_io, indent_level
+        to_html(io) do |inner_io|
+          yield inner_io
         end
       end
     end
   end
 
   macro class_template(&blk)
-    def self.to_html(io, indent_level = 0)
-      ToHtml.to_html_eval_exps(io, indent_level) {{blk}}
+    def self.to_html(io)
+      ToHtml.to_html_eval_exps(io) {{blk}}
     end
 
     def self.to_html
@@ -38,96 +38,87 @@ module ToHtml
 
     def self.to_html
       String.build do |io|
-        to_html(io) do |inner_io, indent_level|
-          yield inner_io, indent_level
+        to_html(io) do |inner_io|
+          yield inner_io
         end
       end
     end
   end
 
   # :nodoc:
-  macro to_html_eval_exps(io, indent_level, &blk)
+  macro to_html_eval_exps(io, &blk)
     {% if blk.body.is_a?(Expressions) %}
-      {% for exp, index in blk.body.expressions %}
-        ToHtml.to_html_eval_exp({{io}}, {{indent_level}}, {{!(index == blk.body.expressions.size - 1)}}) do
+      {% for exp in blk.body.expressions %}
+        ToHtml.to_html_eval_exp({{io}}) do
           {{exp}}
         end
       {% end %}
     {% else %}
-      ToHtml.to_html_eval_exp({{io}}, {{indent_level}}, false) do
+      ToHtml.to_html_eval_exp({{io}}) do
         {{blk.body}}
       end
     {% end %}
   end
 
   # :nodoc:
-  macro to_html_eval_exp(io, indent_level, break_line = true, &blk)
+  macro to_html_eval_exp(io, &blk)
     {% if blk.body.is_a?(Call) && blk.body.receiver.nil? && ToHtml::VOID_TAG_NAMES.includes?(blk.body.name.stringify) %}
-      ToHtml.to_html_add_void_tag({{io}}, {{indent_level}}, {{break_line}}, {{blk.body}})
+      ToHtml.to_html_add_void_tag({{io}}, {{blk.body}})
     {% elsif blk.body.is_a?(Call) && blk.body.receiver.nil? && ToHtml::TAG_NAMES.keys.includes?(blk.body.name.stringify) %}
-      ToHtml.to_html_add_tag({{io}}, {{indent_level}}, {{break_line}}, {{blk.body}})
+      ToHtml.to_html_add_tag({{io}}, {{blk.body}})
     {% elsif blk.body.is_a?(Call) && blk.body.receiver.nil? && blk.body.name.stringify == "doctype" %}
       {{io}} << "<!DOCTYPE {{blk.body.args.first.id}}>"
     {% elsif blk.body.is_a?(Call) && blk.body.receiver && blk.body.name.stringify == "each" %}
-      {{blk.body.receiver}}.each_with_index do {% if !blk.body.block.args.empty? %} |{{blk.body.block.args.splat}}, %index| {% end %}
-        ToHtml.to_html_eval_exps({{io}}, {{indent_level}}) do
+      {{blk.body.receiver}}.each do {% if !blk.body.block.args.empty? %} |{{blk.body.block.args.splat}}| {% end %}
+        ToHtml.to_html_eval_exps({{io}}) do
           {{blk.body.block.body}}
         end
-        {% if flag?(:to_html_pretty) %}
-          {{io}} << "\n" unless %index == {{blk.body.receiver}}.size - 1
-        {% end %}
       end
     {% elsif blk.body.is_a?(Call) && blk.body.receiver && blk.body.name.stringify == "to_html" && blk.body.block %}
-      {{blk.body.receiver}}.to_html({{io}}, {{indent_level}}) do |%io, %indent_level|
-        ToHtml.to_html_eval_exps(%io, %indent_level) do
+      {{blk.body.receiver}}.to_html({{io}}) do |%io|
+        ToHtml.to_html_eval_exps(%io) do
           {{blk.body.block.body}}
         end
       end
     {% elsif blk.body.is_a?(Call) && blk.body.name.stringify == "super" && blk.body.block %}
       super do
-        ToHtml.to_html_eval_exps({{io}}, {{indent_level}}) do
+        ToHtml.to_html_eval_exps({{io}}) do
           {{blk.body.block.body}}
         end
       end
     {% elsif blk.body.is_a?(Call) && blk.body.name.stringify == "previous_def" && blk.body.block %}
       previous_def do
-        ToHtml.to_html_eval_exps({{io}}, {{indent_level}}) do
+        ToHtml.to_html_eval_exps({{io}}) do
           {{blk.body.block.body}}
         end
       end
     {% elsif blk.body.is_a?(If) %}
       if {{blk.body.cond}}
         {% if !blk.body.then.nil? %}
-          ToHtml.to_html_eval_exps({{io}}, {{indent_level}}) do
+          ToHtml.to_html_eval_exps({{io}}) do
             {{blk.body.then}}
           end
-          {% if flag?(:to_html_pretty) && break_line %}
-            {{io}} << "\n"
-          {% end %}
         {% end %}
       {% if !blk.body.else.nil? %}
         else
-          ToHtml.to_html_eval_exps({{io}}, {{indent_level}}) do
+          ToHtml.to_html_eval_exps({{io}}) do
             {{blk.body.else}}
           end
-          {% if flag?(:to_html_pretty) && break_line %}
-            {{io}} << "\n"
-          {% end %}
       {% end %}
       end
     {% elsif blk.body.is_a?(MacroIf) %}
       \{% if {{blk.body.cond}} %}
-        ToHtml.to_html_eval_exps({{io}}, {{indent_level}}) do
+        ToHtml.to_html_eval_exps({{io}}) do
           {{blk.body.then}}
         end
       \{% else %}
-        ToHtml.to_html_eval_exps({{io}}, {{indent_level}}) do
+        ToHtml.to_html_eval_exps({{io}}) do
           {{blk.body.else}}
         end
       \{% end %}
     {% elsif blk.body.is_a?(MacroFor) %}
       \{% for {{blk.body.vars.splat}} in {{blk.body.exp}} %}
-        ToHtml.to_html_eval_exps({{io}}, {{indent_level}}) do
+        ToHtml.to_html_eval_exps({{io}}) do
           {{blk.body.body.expressions.join("").id}}
         end
       \{% end %}
@@ -137,29 +128,23 @@ module ToHtml
       # Don't print this to the IO
       {{blk.body}}
     {% elsif blk.body.is_a?(Yield) %}
-      yield {{io}}, {{indent_level}}
+      yield {{io}}
     {% elsif blk.body.is_a?(Nop) %}
       # do nothing
     {% else %}
       %var = {{blk.body}}
       if %var.responds_to?(:to_html)
-        %var.to_html({{io}}, {{indent_level}})
+        %var.to_html({{io}})
       else
-        {% if flag?(:to_html_pretty) %}
-          {{io}} << "  " * {{indent_level}}
-        {% end %}
         {{io}} << %var
       end
     {% end %}
   end
 
   # :nodoc:
-  macro to_html_add_tag(io, indent_level, break_line, call)
+  macro to_html_add_tag(io, call)
     {% if call.named_args %}
       ToHtml.{{ "#{call.name}_typecheck(#{call.named_args.splat})".id }}
-    {% end %}
-    {% if flag?(:to_html_pretty) %}
-      {{io}} << "  " * {{indent_level}}
     {% end %}
     {% if call.args.empty? && !call.named_args && call.block && call.block.body.is_a?(StringLiteral) %}
       {{io}} << {{"<" + ToHtml::TAG_NAMES[call.name.stringify] + ">" + call.block.body + "</" + ToHtml::TAG_NAMES[call.name.stringify] + ">"}}
@@ -201,32 +186,17 @@ module ToHtml
         {% if call.block.body.is_a?(StringLiteral) %}
           {{io}} << {{call.block.body}}
         {% else %}
-          {% if flag?(:to_html_pretty) %}
-            {{io}} << "\n"
-          {% end %}
-          ToHtml.to_html_eval_exps({{io}}, ({{indent_level}} + 1)) {{call.block}}
-          {% if flag?(:to_html_pretty) %}
-            {{io}} << "\n"
-          {% end %}
-          {% if flag?(:to_html_pretty) %}
-            {{io}} << "  " * {{indent_level}}
-          {% end %}
+          ToHtml.to_html_eval_exps({{io}}) {{call.block}}
         {% end %}
       {% end %}
       {{io}} << "</{{ToHtml::TAG_NAMES[call.name.stringify].id}}>"
-      {% if flag?(:to_html_pretty) && break_line %}
-        {{io}} << "\n"
-      {% end %}
     {% end %}
   end
 
   # :nodoc:
-  macro to_html_add_void_tag(io, indent_level, break_line, call)
+  macro to_html_add_void_tag(io, call)
     {% if call.named_args %}
       ToHtml.{{ "#{call.name}_typecheck(#{call.named_args.splat})".id }}
-    {% end %}
-    {% if flag?(:to_html_pretty) %}
-      {{io}} << "  " * {{indent_level}}
     {% end %}
     {% if call.args.empty? && !call.named_args %}
       {{io}} << "<{{call.name}}>"
@@ -260,9 +230,6 @@ module ToHtml
       {{io}} << " " unless %attr_hash.empty?
       {{io}} << %attr_hash
       {{io}} << ">"
-    {% end %}
-    {% if flag?(:to_html_pretty) && break_line %}
-      {{io}} << "\n"
     {% end %}
   end
 end

--- a/src/tag_typechecks.cr
+++ b/src/tag_typechecks.cr
@@ -223,7 +223,7 @@ module ToHtml
     def section_typecheck(**args)
     end
 
-    def select_typecheck(**args)
+    def select_tag_typecheck(**args)
     end
 
     def small_typecheck(**args)


### PR DESCRIPTION
I personally never used it in practice, it just bloated the code. As this feature could only be turned on by an undocumented compiler flag, I doubt anyone has ever used it. This library is primarily meant for rendering server responses, where the browser pretty-prints the page code in its developer tool anyway. No need to send the extra whitespace through the network every time.