### PR TITLE
Introduce inline templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,52 @@ end
 puts ClassView.to_html
 ```
 
+### Inline Templates
+
+```crystal
+require "to_html"
+
+class InlineView
+  getter names : Array(String)
+
+  def initialize(@names); end
+
+  ToHtml.inline_template :greeting do |who|
+    p { "Hello #{who}" }
+  end
+
+  ToHtml.instance_template do
+    div do
+      names.each do |name|
+        greeting(name)
+      end
+    end
+  end
+end
+
+puts InlineView.new(["Ada", "Grace"]).to_html
+```
+
+### Class Inline Templates
+
+```crystal
+require "to_html"
+
+class InlineClassView
+  ToHtml.class_inline_template :title_fragment do |text|
+    h2 { text }
+  end
+
+  ToHtml.class_template do
+    section do
+      title_fragment("Hello")
+    end
+  end
+end
+
+puts InlineClassView.to_html
+```
+
 ### Compile-time Control Flow (MacroIf / MacroFor)
 
 In addition to runtime `if`/`#each`, you can also use Crystal's macro control flow (`{% if %}` / `{% for %}`) inside templates. This runs at compile-time and can be used to generate markup based on compile-time information such as compiler flags or `@type`.

--- a/spec/instance_template/inline_template_spec.cr
+++ b/spec/instance_template/inline_template_spec.cr
@@ -1,0 +1,104 @@
+require "../spec_helper"
+
+module ToHtml::InstanceTemplate::InlineTemplateSpec
+  class View
+    ToHtml.inline_template :inline_fragment do
+      h1 { "Hello" }
+    end
+
+    ToHtml.instance_template do
+      div do
+        inline_fragment
+      end
+    end
+  end
+
+  class VariableView
+    getter name : String
+
+    def initialize(@name)
+    end
+
+    ToHtml.inline_template :greeting do
+      p { "Hello #{name}" }
+    end
+
+    ToHtml.instance_template do
+      div do
+        greeting
+      end
+    end
+  end
+
+  class ArgumentView
+    ToHtml.inline_template :greeting do |name|
+      p { "Hi #{name}" }
+    end
+
+    ToHtml.instance_template do
+      div do
+        greeting("Ada")
+      end
+    end
+  end
+
+  class ClassView
+    ToHtml.class_inline_template :title_fragment do |title|
+      h2 { title }
+    end
+
+    ToHtml.class_template do
+      section do
+        title_fragment("Hello")
+      end
+    end
+  end
+
+  describe "View#to_html with inline template" do
+    it "renders the inline template proc" do
+      expected = <<-HTML
+      <div>
+        <h1>Hello</h1>
+      </div>
+      HTML
+
+      View.new.to_html.should eq(expected.squish)
+    end
+  end
+
+  describe "inline template proc access to instance variables" do
+    it "renders when called from the instance template" do
+      expected = <<-HTML
+      <div>
+        <p>Hello Ada</p>
+      </div>
+      HTML
+
+      VariableView.new("Ada").to_html.should eq(expected.squish)
+    end
+  end
+
+  describe "inline template arguments" do
+    it "renders when called from the instance template" do
+      expected = <<-HTML
+      <div>
+        <p>Hi Ada</p>
+      </div>
+      HTML
+
+      ArgumentView.new.to_html.should eq(expected.squish)
+    end
+  end
+
+  describe "class inline templates" do
+    it "render when called from the class template" do
+      expected = <<-HTML
+      <section>
+        <h2>Hello</h2>
+      </section>
+      HTML
+
+      ClassView.to_html.should eq(expected.squish)
+    end
+  end
+end

--- a/src/globals.cr
+++ b/src/globals.cr
@@ -8,6 +8,14 @@ macro class_template(&blk)
   ToHtml.class_template {{blk}}
 end
 
+macro inline_template(name, &blk)
+  ToHtml.inline_template {{name}} {{blk}}
+end
+
+macro class_inline_template(name, &blk)
+  ToHtml.class_inline_template {{name}} {{blk}}
+end
+
 macro instance_tag_attrs(&blk)
   ToHtml.instance_tag_attrs {{blk}}
 end

--- a/src/instance_template.cr
+++ b/src/instance_template.cr
@@ -42,6 +42,24 @@ module ToHtml
     end
   end
 
+  macro inline_template(name, &blk)
+    def {{name.id}}({{blk.args.splat}})
+      ->(io : IO) do
+        ToHtml.to_html_eval_exps(io, 0) {{blk}}
+        nil
+      end
+    end
+  end
+
+  macro class_inline_template(name, &blk)
+    def self.{{name.id}}({{blk.args.splat}})
+      ->(io : IO) do
+        ToHtml.to_html_eval_exps(io, 0) {{blk}}
+        nil
+      end
+    end
+  end
+
   # :nodoc:
   macro to_html_eval_exps(io, indent_level, &blk)
     {% if blk.body.is_a?(Expressions) %}
@@ -139,7 +157,9 @@ module ToHtml
       # do nothing
     {% else %}
       %var = {{blk.body}}
-      if %var.responds_to?(:to_html)
+      if %var.is_a?(Proc(IO, Nil))
+        %var.call({{io}})
+      elsif %var.responds_to?(:to_html)
         %var.to_html({{io}}, {{indent_level}})
       else
         {% if flag?(:to_html_pretty) %}


### PR DESCRIPTION
Benchmark
```
         ecr   1.64M (610.99ns) (± 2.75%)  4.27kB/op        fastest
     to_html 891.01k (  1.12µs) (± 2.67%)  5.52kB/op   1.84× slower
   blueprint 538.81k (  1.86µs) (± 1.77%)   4.9kB/op   3.04× slower
     markout 198.00k (  5.05µs) (± 4.03%)  8.08kB/op   8.27× slower
html_builder  66.92k ( 14.94µs) (± 2.47%)  10.4kB/op  24.46× slower
       water  64.43k ( 15.52µs) (± 3.14%)  11.2kB/op  25.40× slower
```