### PR TITLE
Typecheck <link rel> attribute

### DIFF
--- a/spec/instance_template/tags/link_spec.cr
+++ b/spec/instance_template/tags/link_spec.cr
@@ -1,0 +1,29 @@
+require "../../spec_helper"
+
+module ToHtml::InstanceTemplate::Tags::LinkSpec
+  class MyView
+    ToHtml.instance_template do
+      link href: "style.css", rel: :stylesheet
+      link href: "https://example.com", rel: :canonical
+      link href: "https://example.com", rel: :dns_prefetch
+      link href: "custom", rel: "custom"
+      link href: "no-rel.css"
+    end
+  end
+
+  describe "MyView#to_html" do
+    it "should return the correct HTML" do
+      view = MyView.new
+
+      expected = <<-HTML.squish
+      <link href="style.css" rel="stylesheet">
+      <link href="https://example.com" rel="canonical">
+      <link href="https://example.com" rel="dns-prefetch">
+      <link href="custom" rel="custom">
+      <link href="no-rel.css">
+      HTML
+
+      view.to_html.should eq(expected)
+    end
+  end
+end

--- a/src/attr_enums/link_rel.cr
+++ b/src/attr_enums/link_rel.cr
@@ -1,0 +1,81 @@
+module ToHtml
+  module AttrEnums
+    # Source: https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel
+    enum LinkRel
+      Alternate
+      Author
+      Canonical
+      CompressionDictionary
+      DnsPrefetch
+      Expect
+      Help
+      Icon
+      License
+      Manifest
+      Me
+      Modulepreload
+      Next
+      Pingback
+      Preconnect
+      Prefetch
+      Preload
+      Prerender
+      Prev
+      PrivacyPolicy
+      Search
+      Stylesheet
+      TermsOfService
+
+      def to_s : String
+        case self
+        in Alternate
+          "alternate"
+        in Author
+          "author"
+        in Canonical
+          "canonical"
+        in CompressionDictionary
+          "compression-dictionary"
+        in DnsPrefetch
+          "dns-prefetch"
+        in Expect
+          "expect"
+        in Help
+          "help"
+        in Icon
+          "icon"
+        in License
+          "license"
+        in Manifest
+          "manifest"
+        in Me
+          "me"
+        in Modulepreload
+          "modulepreload"
+        in Next
+          "next"
+        in Pingback
+          "pingback"
+        in Preconnect
+          "preconnect"
+        in Prefetch
+          "prefetch"
+        in Preload
+          "preload"
+        in Prerender
+          "prerender"
+        in Prev
+          "prev"
+        in PrivacyPolicy
+          "privacy-policy"
+        in Search
+          "search"
+        in Stylesheet
+          "stylesheet"
+        in TermsOfService
+          "terms-of-service"
+        end
+      end
+    end
+  end
+end

--- a/src/tag_typechecks.cr
+++ b/src/tag_typechecks.cr
@@ -424,8 +424,8 @@ module ToHtml
       args.merge(type: type)
     end
 
-    def link_typecheck(**args)
-      args
+    def link_typecheck(rel : (AttrEnums::LinkRel | String | Nil) = nil, **args)
+      args.merge(rel: rel)
     end
 
     def meta_typecheck(name : (AttrEnums::MetaName | String | Nil) = nil, **args)


### PR DESCRIPTION
- Add AttrEnums::LinkRel and wire into link_typecheck so symbol rel values are validated and serialized properly.
- Add spec for link rel symbols (including hyphenated tokens).