### PR TITLE
Support case statements in templates

### DIFF
--- a/spec/instance_template/case_spec.cr
+++ b/spec/instance_template/case_spec.cr
@@ -1,0 +1,83 @@
+require "../spec_helper"
+
+module ToHtml::InstanceTemplate::CaseSpec
+  enum Kind
+    A
+    B
+    Other
+  end
+
+  class MyView
+    getter kind : Kind
+
+    def initialize(@kind)
+    end
+
+    ToHtml.instance_template do
+      case kind
+      when Kind::A
+        p { "A" }
+      when Kind::B
+        div do
+          span { "B" }
+        end
+      else
+        i { "Other" }
+      end
+
+      div do
+        case
+        when kind == Kind::A
+          strong { "inner-a" }
+        else
+          em { "inner-not-a" }
+        end
+      end
+    end
+
+    describe "MyView#to_html" do
+      it "renders the correct HTML for Kind::A" do
+        expected = <<-HTML
+        <p>A</p>
+        <div>
+          <strong>
+            inner-a
+          </strong>
+        </div>
+        HTML
+
+        MyView.new(Kind::A).to_html.should eq(expected.squish)
+      end
+
+      it "renders the correct HTML for Kind::B" do
+        expected = <<-HTML
+        <div>
+          <span>
+            B
+          </span>
+        </div>
+        <div>
+          <em>
+            inner-not-a
+          </em>
+        </div>
+        HTML
+
+        MyView.new(Kind::B).to_html.should eq(expected.squish)
+      end
+
+      it "renders the correct HTML for Kind::Other" do
+        expected = <<-HTML
+        <i>Other</i>
+        <div>
+          <em>
+            inner-not-a
+          </em>
+        </div>
+        HTML
+
+        MyView.new(Kind::Other).to_html.should eq(expected.squish)
+      end
+    end
+  end
+end

--- a/src/instance_template.cr
+++ b/src/instance_template.cr
@@ -131,11 +131,7 @@ module ToHtml
       {% end %}
       end
     {% elsif blk.body.is_a?(Case) %}
-      {% if blk.body.cond.is_a?(Nop) %}
-        case
-      {% else %}
-        case {{blk.body.cond}}
-      {% end %}
+      case {{blk.body.cond}}
       {% for w in blk.body.whens %}
         when {{w.conds.splat}}
           ToHtml.to_html_eval_exps({{io}}, {{indent_level}}) do

--- a/src/instance_template.cr
+++ b/src/instance_template.cr
@@ -130,6 +130,31 @@ module ToHtml
           {% end %}
       {% end %}
       end
+    {% elsif blk.body.is_a?(Case) %}
+      {% if blk.body.cond.is_a?(Nop) %}
+        case
+      {% else %}
+        case {{blk.body.cond}}
+      {% end %}
+      {% for w in blk.body.whens %}
+        when {{w.conds.splat}}
+          ToHtml.to_html_eval_exps({{io}}, {{indent_level}}) do
+            {{w.body}}
+          end
+          {% if flag?(:to_html_pretty) && break_line %}
+            {{io}} << "\n"
+          {% end %}
+      {% end %}
+      {% if !blk.body.else.is_a?(Nop) %}
+        else
+          ToHtml.to_html_eval_exps({{io}}, {{indent_level}}) do
+            {{blk.body.else}}
+          end
+          {% if flag?(:to_html_pretty) && break_line %}
+            {{io}} << "\n"
+          {% end %}
+      {% end %}
+      end
     {% elsif blk.body.is_a?(MacroIf) %}
       \{% if {{blk.body.cond}} %}
         ToHtml.to_html_eval_exps({{io}}, {{indent_level}}) do


### PR DESCRIPTION
Adds support for evaluating case statements inside templates so nested tags render correctly.

Includes specs covering when/else branches and expressionless case usage.