### PR TITLE
Support each_with_index and times in instance templates

### DIFF
--- a/spec/instance_template/iterator_blocks_spec.cr
+++ b/spec/instance_template/iterator_blocks_spec.cr
@@ -1,0 +1,95 @@
+require "../spec_helper"
+
+module ToHtml::InstanceTemplate::IteratorBlocksSpec
+  class IndexedItem
+    getter value : String
+
+    def initialize(@value)
+    end
+
+    ToHtml.instance_template do
+      em { value }
+    end
+  end
+
+  class IndexedList
+    getter items : Array(String)
+
+    def initialize(@items)
+    end
+
+    ToHtml.instance_template do
+      ul do
+        items.each_with_index do |item, idx|
+          li do
+            if idx.even?
+              span { idx.to_s }
+            else
+              IndexedItem.new(item)
+            end
+
+            unless idx == items.size - 1
+              small { "present" }
+            end
+          end
+        end
+      end
+    end
+  end
+
+  class TimesList
+    ToHtml.instance_template do
+      ol do
+        3.times do |i|
+          li do
+            if i.even?
+              "even"
+            else
+              "odd"
+            end
+          end
+        end
+
+        2.times do
+          li { "tail" }
+        end
+      end
+    end
+  end
+
+  describe "iterator blocks" do
+    it "supports each_with_index with nested template control flow" do
+      expected = <<-HTML
+      <ul>
+        <li>
+          <span>
+            0
+          </span>
+          <small>present</small>
+        </li>
+        <li>
+          <em>
+            two
+          </em>
+        </li>
+      </ul>
+      HTML
+
+      IndexedList.new(["one", "two"]).to_html.should eq(expected.squish)
+    end
+
+    it "supports times with and without block args" do
+      expected = <<-HTML
+      <ol>
+        <li>even</li>
+        <li>odd</li>
+        <li>even</li>
+        <li>tail</li>
+        <li>tail</li>
+      </ol>
+      HTML
+
+      TimesList.new.to_html.should eq(expected.squish)
+    end
+  end
+end

--- a/src/instance_template.cr
+++ b/src/instance_template.cr
@@ -83,14 +83,44 @@ module ToHtml
       ToHtml.to_html_add_tag({{io}}, {{indent_level}}, {{break_line}}, {{blk.body}})
     {% elsif blk.body.is_a?(Call) && blk.body.receiver.nil? && blk.body.name.stringify == "doctype" %}
       {{io}} << "<!DOCTYPE {{blk.body.args.first.id}}>"
-    {% elsif blk.body.is_a?(Call) && blk.body.receiver && blk.body.name.stringify == "each" %}
-      {{blk.body.receiver}}.each_with_index do {% if !blk.body.block.args.empty? %} |{{blk.body.block.args.splat}}, %index| {% end %}
+    {% elsif blk.body.is_a?(Call) && blk.body.receiver && blk.body.block && blk.body.name.stringify == "each" %}
+      {% if flag?(:to_html_pretty) %}
+        %to_html_each_break_line = false
+      {% end %}
+      {{blk.body.receiver}}.each do {% if !blk.body.block.args.empty? %} |{{blk.body.block.args.splat}}| {% end %}
+        {% if flag?(:to_html_pretty) %}
+          {{io}} << "\n" if %to_html_each_break_line
+          %to_html_each_break_line = true
+        {% end %}
         ToHtml.to_html_eval_exps({{io}}, {{indent_level}}) do
           {{blk.body.block.body}}
         end
+      end
+    {% elsif blk.body.is_a?(Call) && blk.body.receiver && blk.body.block && blk.body.name.stringify == "each_with_index" %}
+      {% if flag?(:to_html_pretty) %}
+        %to_html_each_with_index_break_line = false
+      {% end %}
+      {{blk.body.receiver}}.each_with_index do {% if !blk.body.block.args.empty? %} |{{blk.body.block.args.splat}}| {% end %}
         {% if flag?(:to_html_pretty) %}
-          {{io}} << "\n" unless %index == {{blk.body.receiver}}.size - 1
+          {{io}} << "\n" if %to_html_each_with_index_break_line
+          %to_html_each_with_index_break_line = true
         {% end %}
+        ToHtml.to_html_eval_exps({{io}}, {{indent_level}}) do
+          {{blk.body.block.body}}
+        end
+      end
+    {% elsif blk.body.is_a?(Call) && blk.body.receiver && blk.body.block && blk.body.name.stringify == "times" %}
+      {% if flag?(:to_html_pretty) %}
+        %to_html_times_break_line = false
+      {% end %}
+      {{blk.body.receiver}}.times do {% if !blk.body.block.args.empty? %} |{{blk.body.block.args.splat}}| {% end %}
+        {% if flag?(:to_html_pretty) %}
+          {{io}} << "\n" if %to_html_times_break_line
+          %to_html_times_break_line = true
+        {% end %}
+        ToHtml.to_html_eval_exps({{io}}, {{indent_level}}) do
+          {{blk.body.block.body}}
+        end
       end
     {% elsif blk.body.is_a?(Call) && blk.body.receiver && blk.body.name.stringify == "to_html" && blk.body.block %}
       {{blk.body.receiver}}.to_html({{io}}, {{indent_level}}) do |%io, %indent_level|


### PR DESCRIPTION
## Summary
- Extend template iterator block handling to support `each_with_index` and `times` (receiver + block), alongside existing `each`.
- Ensure iterator block bodies are evaluated through the template evaluator so nested tag calls, string literals, control flow, and `to_html` objects render consistently.
- Preserve block argument behavior, including omitted args for `times` blocks.

## Changes
- Updated `src/instance_template.cr` in `ToHtml.to_html_eval_exp`:
- Added allowlisted handling for `each_with_index` blocks.
- Added allowlisted handling for `times` blocks.
- Kept `each` aligned with the same block-evaluation behavior and made iterator pretty-print separation independent of injected index args (so omitted block args are safe).
- Added `spec/instance_template/iterator_blocks_spec.cr`:
- `each_with_index` example with nested tags, literals, and `if`/`unless`.
- `times` examples covering both `do |i|` and `do ... end` forms, including nested control flow.

## Testing
- Ran: `crystal spec` (using `CRYSTAL_CACHE_DIR=/tmp/crystal-cache-html` because default cache path is not writable in this environment)
- Result: 34 examples, 0 failures