### PR TITLE
Append duplicate data and aria attribute values

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ puts NamedArgumentsView.new.to_html
 #### `data` / `aria` Helpers
 
 You can define `data-*` and `aria-*` attributes via `data:` / `aria:` hashes or named tuples.
-When multiple sources assign the same `data-*` / `aria-*` key, the last assignment wins.
+When multiple sources assign the same `data-*` / `aria-*` key, all values are joined with spaces.
 
 ```crystal
 require "to_html"
@@ -316,7 +316,7 @@ class DataAriaView
   end
 end
 
-# <div data-foo="from-hash" data-user-id="42" data-active="true" aria-label="Profile" aria-hidden="false"></div>
+# <div data-foo="from-tuple from-explicit from-hash" data-user-id="42" data-active="true" aria-label="Profile" aria-hidden="false"></div>
 puts DataAriaView.new.to_html
 ```
 

--- a/spec/instance_template/data_aria_attributes_spec.cr
+++ b/spec/instance_template/data_aria_attributes_spec.cr
@@ -59,8 +59,11 @@ module ToHtml::InstanceTemplate::DataAriaAttributesSpec
       TypeView.new.to_html.should eq(%(<div data-enabled="true" data-count="7" data-ratio="2.5" aria-hidden="false"></div>))
     end
 
-    it "merges array, tuple, to_html_attrs, and named args with last-write-wins semantics" do
-      MergeView.new.to_html.should eq(%(<div data-foo="named-hash-last" aria-label="named-label-last" data-baz="true" aria-hidden="false" data-count="2.5" data-prefixed="normalized" aria-current="false"></div>))
+    it "merges array, tuple, to_html_attrs, and named args by joining duplicate values" do
+      expected = %(<div data-foo="provider-hash provider-explicit array-hash tuple-explicit named-explicit named-hash-last" data-bar="1" ) +
+                 %(aria-label="provider-label provider-explicit-label array-label tuple-explicit-label named-explicit-label named-label-last" data-baz="true" aria-hidden="false" data-count="2.5" data-prefixed="normalized" aria-current="false"></div>)
+
+      MergeView.new.to_html.should eq(expected)
     end
 
     it "normalizes symbol and string keys for data/aria hashes" do

--- a/src/attribute_hash.cr
+++ b/src/attribute_hash.cr
@@ -26,7 +26,7 @@ module ToHtml
       key = key.to_s
 
       if prefixed_key = normalize_explicit_prefixed_key(key)
-        assign_prefixed_value(prefixed_key, value)
+        append_attribute(prefixed_key, value)
         return
       end
 
@@ -34,11 +34,7 @@ module ToHtml
         return if assign_prefixed_hash(key, value)
       end
 
-      if attributes.has_key?(key)
-        attributes[key] += " #{value}" if value
-      else
-        attributes[key] = value.to_s
-      end
+      append_attribute(key, value)
     end
 
     def empty?
@@ -106,6 +102,10 @@ module ToHtml
     end
 
     private def assign_prefixed_value(key : String, value)
+      append_attribute(key, value)
+    end
+
+    private def append_attribute(key : String, value)
       if attributes.has_key?(key)
         attributes[key] += " #{value}" if value
       else

--- a/src/attribute_hash.cr
+++ b/src/attribute_hash.cr
@@ -13,7 +13,7 @@ module ToHtml
       key = key.to_s
 
       if prefixed_key = normalize_explicit_prefixed_key(key)
-        attributes[prefixed_key] = value.to_s
+        assign_prefixed_value(prefixed_key, value)
         return
       end
 
@@ -102,11 +102,15 @@ module ToHtml
     end
 
     private def assign_prefixed_value(key : String, _value : Nil)
-      attributes.delete(key)
+      # Keep data/aria nil behavior aligned with regular attributes: nil never appends.
     end
 
     private def assign_prefixed_value(key : String, value)
-      attributes[key] = value.to_s
+      if attributes.has_key?(key)
+        attributes[key] += " #{value}" if value
+      else
+        attributes[key] = value.to_s
+      end
     end
   end
 end

--- a/src/attribute_hash.cr
+++ b/src/attribute_hash.cr
@@ -11,9 +11,11 @@ module ToHtml
 
     def []=(key, value : Bool)
       key = key.to_s
+      normalized_key = key.gsub("_", "-")
 
-      if prefixed_key = normalize_explicit_prefixed_key(key)
-        assign_prefixed_value(prefixed_key, value)
+      if normalized_key.starts_with?("data-") || normalized_key.starts_with?("aria-")
+        return if normalized_key == "data-" || normalized_key == "aria-"
+        append_attribute(normalized_key, value)
         return
       end
 
@@ -24,9 +26,11 @@ module ToHtml
 
     def []=(key, value)
       key = key.to_s
+      normalized_key = key.gsub("_", "-")
 
-      if prefixed_key = normalize_explicit_prefixed_key(key)
-        append_attribute(prefixed_key, value)
+      if normalized_key.starts_with?("data-") || normalized_key.starts_with?("aria-")
+        return if normalized_key == "data-" || normalized_key == "aria-"
+        append_prefixed_value(normalized_key, value)
         return
       end
 
@@ -62,9 +66,9 @@ module ToHtml
         if key.starts_with?(prefix_with_separator)
           next if key.size == prefix_with_separator.size
 
-          assign_prefixed_value(key, raw_value)
+          append_prefixed_value(key, raw_value)
         else
-          assign_prefixed_value("#{prefix_with_separator}#{key}", raw_value)
+          append_prefixed_value("#{prefix_with_separator}#{key}", raw_value)
         end
       end
 
@@ -75,34 +79,21 @@ module ToHtml
       false
     end
 
-    private def normalize_explicit_prefixed_key(key : String) : String?
-      key = key.gsub("_", "-")
-
-      if key.starts_with?("data-")
-        return if key == "data-"
-        key
-      elsif key.starts_with?("aria-")
-        return if key == "aria-"
-        key
-      end
-    end
-
     # Nested data/aria maps are flattened recursively into hyphen-separated keys.
-    private def assign_prefixed_value(key : String, value : Hash | NamedTuple)
-      value.each do |raw_key, raw_value|
-        nested_key_part = raw_key.to_s.strip.gsub("_", "-")
-        next if nested_key_part.empty?
+    private def append_prefixed_value(key : String, value)
+      case value
+      when Hash, NamedTuple
+        value.each do |raw_key, raw_value|
+          nested_key_part = raw_key.to_s.strip.gsub("_", "-")
+          next if nested_key_part.empty?
 
-        assign_prefixed_value("#{key}-#{nested_key_part}", raw_value)
+          append_prefixed_value("#{key}-#{nested_key_part}", raw_value)
+        end
+      when Nil
+        # Keep data/aria nil behavior aligned with regular attributes: nil never appends.
+      else
+        append_attribute(key, value)
       end
-    end
-
-    private def assign_prefixed_value(key : String, _value : Nil)
-      # Keep data/aria nil behavior aligned with regular attributes: nil never appends.
-    end
-
-    private def assign_prefixed_value(key : String, value)
-      append_attribute(key, value)
     end
 
     private def append_attribute(key : String, value)


### PR DESCRIPTION
## Summary
- make `AttributeHash` append repeated `data-*` and `aria-*` values instead of overwriting existing values
- keep `nil` assignments for expanded `data-*` and `aria-*` keys as no-ops so previously collected values are preserved
- update the merge spec to assert space-joined duplicate values and refresh the README example/docs

## Testing
- `CRYSTAL_CACHE_DIR=/tmp/crystal-cache- crystal spec`